### PR TITLE
Add Camino route web tracker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,7 @@ wheels/
 # Virtual environments
 .venv
 
-# data folder
-data/
+# data folder - ignore actual route files but keep placeholder
+data/*
+!data/.gitkeep
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY pyproject.toml README.md ./
+RUN pip install --no-cache-dir -e .
+COPY . .
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,26 @@
 # Camino Tracker
 
+A small web application that displays the Camino de Santiago route from León to Santiago de Compostela. The application merges individual KML route sections, computes the total distance, and animates a marker moving along the path from **00:00 10 August** to **00:00 20 August**. Each day's segment is color‑coded and users can search for towns or addresses to see them relative to the moving marker.
+
 ## Data
 
-.kml files of section of the camino de santiago route must be placed in `data/` dir in the root directory of project
+Place the Camino route `.kml` files in the `data/` directory at the project root. Files are combined in alphabetical order.
+
+## Running locally
+
+```bash
+pip install -e .
+python -m app.main
+```
+
+Then open <http://localhost:8000> in your browser.
+
+## Docker
+
+A `Dockerfile` is provided for deployment to platforms such as Fly.io.
+
+```bash
+docker build -t camino-tracker .
+docker run -p 8000:8000 camino-tracker
+```
+

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+# Camino Tracker application package

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+
+from .route_utils import load_route
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+DATA_DIR = BASE_DIR / "data"
+STATIC_DIR = Path(__file__).resolve().parent / "static"
+
+app = FastAPI()
+app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
+
+# Load route data once at startup
+route_geojson, route_meta = load_route(DATA_DIR)
+
+
+@app.get("/")
+def index() -> FileResponse:
+    return FileResponse(STATIC_DIR / "index.html")
+
+
+@app.get("/api/route")
+def api_route() -> dict:
+    return route_geojson
+
+
+@app.get("/api/meta")
+def api_meta() -> dict:
+    return route_meta
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("app.main:app", host="0.0.0.0", port=8000)

--- a/app/route_utils.py
+++ b/app/route_utils.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Tuple
+import xml.etree.ElementTree as ET
+
+from geopy.distance import geodesic
+
+# Time configuration
+START_TIME = datetime(2024, 8, 10, tzinfo=timezone.utc)
+END_TIME = datetime(2024, 8, 20, tzinfo=timezone.utc)
+DAYS = (END_TIME - START_TIME).days
+
+# Colors for each day's segment
+COLORS = [
+    "#ff0000",
+    "#ff7f00",
+    "#ffff00",
+    "#7fff00",
+    "#00ff00",
+    "#00ffff",
+    "#0000ff",
+    "#8b00ff",
+    "#ff00ff",
+    "#ff007f",
+]
+
+
+def parse_kml(file_path: Path) -> List[Tuple[float, float]]:
+    """Extract coordinates from a KML LineString."""
+    tree = ET.parse(file_path)
+    root = tree.getroot()
+    ns = {"kml": "http://www.opengis.net/kml/2.2"}
+    coords: List[Tuple[float, float]] = []
+    for coord_text in root.findall(".//kml:LineString/kml:coordinates", ns):
+        pairs = coord_text.text.strip().split()
+        for pair in pairs:
+            lon, lat, *_ = pair.split(",")
+            coords.append((float(lat), float(lon)))
+    return coords
+
+
+def compute_total_distance(coords: List[Tuple[float, float]]) -> float:
+    """Calculate the total geodesic distance of the route in kilometers."""
+    distance = 0.0
+    for i in range(1, len(coords)):
+        distance += geodesic(coords[i - 1], coords[i]).kilometers
+    return distance
+
+
+def split_into_segments(
+    coords: List[Tuple[float, float]], segment_len_km: float
+) -> List[List[Tuple[float, float]]]:
+    """Split coordinates into segments of approximately ``segment_len_km``."""
+    segments: List[List[Tuple[float, float]]] = []
+    current_segment: List[Tuple[float, float]] = [coords[0]]
+    current_len = 0.0
+    for i in range(1, len(coords)):
+        prev = coords[i - 1]
+        cur = coords[i]
+        step = geodesic(prev, cur).kilometers
+        while current_len + step >= segment_len_km:
+            ratio = (segment_len_km - current_len) / step
+            lat = prev[0] + (cur[0] - prev[0]) * ratio
+            lon = prev[1] + (cur[1] - prev[1]) * ratio
+            current_segment.append((lat, lon))
+            segments.append(current_segment)
+            prev = (lat, lon)
+            step = geodesic(prev, cur).kilometers
+            current_segment = [prev]
+            current_len = 0.0
+        current_segment.append(cur)
+        current_len += step
+    if current_segment:
+        segments.append(current_segment)
+    return segments
+
+
+def build_geojson(segments: List[List[Tuple[float, float]]]) -> dict:
+    """Create a GeoJSON FeatureCollection for the segments."""
+    features = []
+    for idx, segment in enumerate(segments):
+        coords = [[lon, lat] for lat, lon in segment]
+        features.append(
+            {
+                "type": "Feature",
+                "properties": {"day": idx + 1, "color": COLORS[idx % len(COLORS)]},
+                "geometry": {"type": "LineString", "coordinates": coords},
+            }
+        )
+    return {"type": "FeatureCollection", "features": features}
+
+
+def load_route(data_dir: Path) -> tuple[dict, dict]:
+    """Load KML files, compute metadata and return GeoJSON and metadata."""
+    files = sorted(data_dir.glob("*.kml"))
+    if not files:
+        raise FileNotFoundError("No KML files found in data directory")
+
+    coords: List[Tuple[float, float]] = []
+    for file in files:
+        coords.extend(parse_kml(file))
+
+    total_distance_km = compute_total_distance(coords)
+    daily_distance = total_distance_km / DAYS
+    segments = split_into_segments(coords, daily_distance)
+    geojson = build_geojson(segments)
+
+    duration_seconds = (END_TIME - START_TIME).total_seconds()
+    speed_mps = total_distance_km * 1000 / duration_seconds
+
+    meta = {
+        "total_distance_km": total_distance_km,
+        "daily_distance_km": daily_distance,
+        "speed_mps": speed_mps,
+        "start_time": START_TIME.isoformat(),
+        "end_time": END_TIME.isoformat(),
+        "days": DAYS,
+    }
+    return geojson, meta

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Camino Tracker</title>
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+    />
+    <style>
+      #map {
+        height: 100vh;
+        width: 100%;
+      }
+      #search {
+        position: absolute;
+        top: 10px;
+        left: 50%;
+        transform: translateX(-50%);
+        z-index: 1000;
+        background: #fff;
+        padding: 6px;
+        border-radius: 4px;
+        box-shadow: 0 0 5px rgba(0, 0, 0, 0.3);
+      }
+      #search input {
+        width: 200px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="search">
+      <input id="searchBox" type="text" placeholder="Search town or address" />
+      <button id="searchBtn">Search</button>
+    </div>
+    <div id="map"></div>
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script src="/static/script.js"></script>
+  </body>
+</html>

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -1,0 +1,99 @@
+const map = L.map("map").setView([42.5987, -5.5671], 7);
+L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+  attribution: "&copy; OpenStreetMap contributors",
+}).addTo(map);
+
+let routeData;
+let meta;
+let movingMarker;
+let searchMarker;
+let cumulative = [];
+let coords = [];
+let totalLength = 0;
+
+Promise.all([fetch("/api/meta"), fetch("/api/route")])
+  .then((responses) => Promise.all(responses.map((r) => r.json())))
+  .then(([m, r]) => {
+    meta = m;
+    routeData = r;
+    addRoute();
+    setupAnimation();
+  });
+
+function addRoute() {
+  L.geoJSON(routeData, {
+    style: (feature) => ({ color: feature.properties.color, weight: 5 }),
+  }).addTo(map);
+  coords = routeData.features.flatMap((f) =>
+    f.geometry.coordinates.map((c) => [c[1], c[0]])
+  );
+  cumulative = [0];
+  for (let i = 1; i < coords.length; i++) {
+    const d = haversine(coords[i - 1], coords[i]);
+    cumulative.push(cumulative[cumulative.length - 1] + d);
+  }
+  totalLength = cumulative[cumulative.length - 1];
+  movingMarker = L.marker(coords[0]).addTo(map);
+}
+
+function setupAnimation() {
+  updateMarker();
+  setInterval(updateMarker, 10000);
+}
+
+function updateMarker() {
+  const now = Date.now();
+  const start = Date.parse(meta.start_time);
+  const end = Date.parse(meta.end_time);
+  const progress = Math.min(Math.max((now - start) / (end - start), 0), 1);
+  const distance = progress * totalLength;
+  const pos = coordAtDistance(distance);
+  if (pos) {
+    movingMarker.setLatLng(pos);
+  }
+}
+
+function coordAtDistance(d) {
+  for (let i = 1; i < cumulative.length; i++) {
+    if (d <= cumulative[i]) {
+      const ratio = (d - cumulative[i - 1]) / (cumulative[i] - cumulative[i - 1]);
+      const a = coords[i - 1];
+      const b = coords[i];
+      return [a[0] + (b[0] - a[0]) * ratio, a[1] + (b[1] - a[1]) * ratio];
+    }
+  }
+  return null;
+}
+
+function haversine(a, b) {
+  const R = 6371000;
+  const toRad = (deg) => (deg * Math.PI) / 180;
+  const dLat = toRad(b[0] - a[0]);
+  const dLon = toRad(b[1] - a[1]);
+  const lat1 = toRad(a[0]);
+  const lat2 = toRad(b[0]);
+  const s =
+    Math.sin(dLat / 2) ** 2 +
+    Math.sin(dLon / 2) ** 2 * Math.cos(lat1) * Math.cos(lat2);
+  return 2 * R * Math.atan2(Math.sqrt(s), Math.sqrt(1 - s));
+}
+
+document.getElementById("searchBtn").addEventListener("click", async () => {
+  const q = document.getElementById("searchBox").value;
+  if (!q) return;
+  const res = await fetch(
+    `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(
+      q
+    )}`
+  );
+  const data = await res.json();
+  if (data.length === 0) return;
+  const { lat, lon, display_name } = data[0];
+  if (searchMarker) map.removeLayer(searchMarker);
+  searchMarker = L.marker([lat, lon]).addTo(map);
+  map.setView([lat, lon], 13);
+  const dist = haversine([lat, lon], movingMarker.getLatLng()) / 1000;
+  searchMarker
+    .bindPopup(`${display_name}<br>${dist.toFixed(1)} km from tracker`)
+    .openPopup();
+});

--- a/main.py
+++ b/main.py
@@ -1,6 +1,0 @@
-def main():
-    print("Hello from camino-tracker!")
-
-
-if __name__ == "__main__":
-    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,15 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "camino-tracker"
 version = "0.1.0"
-description = "Add your description here"
+description = "Web app to visualize the Camino de Santiago route"
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = []
+dependencies = [
+    "fastapi",
+    "uvicorn[standard]",
+    "geopy",
+]


### PR DESCRIPTION
## Summary
- parse and merge Camino de Santiago KML segments, compute length and constant speed
- serve animated route and metadata via FastAPI with searchable Leaflet map
- add Dockerfile and usage docs for Fly.io deployment

## Testing
- `pip install -e .` *(failed: Could not find a version that satisfies the requirement setuptools>=68)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893e5cbf8488324bbe130b8e261f6f2