### PR TITLE
Fix imports and ensure uv integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Place the Camino route `.kml` files in the `data/` directory at the project root
 ## Running locally
 
 ```bash
-pip install -e .
-python -m app.main
+# Install dependencies and run the application using uv
+uv run python -m app.main
 ```
 
 Then open <http://localhost:8000> in your browser.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,11 @@ dependencies = [
     "uvicorn[standard]",
     "geopy",
 ]
+
+[tool.setuptools]
+# Use the ``src`` directory for the project packages so that installation via
+# uv/setuptools picks up the application package correctly.
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,20 +1,29 @@
+"""Main application entry point."""
+
 from pathlib import Path
 
 from fastapi import FastAPI
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
-from .route_utils import load_route
+# Use an absolute import so the module works whether executed as a script or a
+# package. This avoids import errors when the code is relocated.
+from app.route_utils import load_route
 
-BASE_DIR = Path(__file__).resolve().parent.parent
+# Repository root (two levels above this file: src/app/main.py -> project root)
+BASE_DIR = Path(__file__).resolve().parents[2]
 DATA_DIR = BASE_DIR / "data"
 STATIC_DIR = Path(__file__).resolve().parent / "static"
 
 app = FastAPI()
 app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
-# Load route data once at startup
-route_geojson, route_meta = load_route(DATA_DIR)
+# Load route data once at startup. If the data directory is missing or empty,
+# fall back to empty dictionaries so the application can still start.
+try:
+    route_geojson, route_meta = load_route(DATA_DIR)
+except FileNotFoundError:
+    route_geojson, route_meta = {}, {}
 
 
 @app.get("/")


### PR DESCRIPTION
## Summary
- fix app imports and handle missing data gracefully
- configure setuptools to use src layout
- document uv usage for running the app

## Testing
- `uv run python -m app.main`
- `uv run python -m py_compile src/app/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6893e9dd0760832499b5ec10b65499a5