### PR TITLE
Add configurable start/end dates and countdown

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,10 +1,12 @@
 """Main application entry point."""
 
 from pathlib import Path
+from datetime import datetime
 
 from fastapi import FastAPI
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
 
 # Use an absolute import so the module works whether executed as a script or a
 # package. This avoids import errors when the code is relocated.
@@ -31,6 +33,11 @@ def index() -> FileResponse:
     return FileResponse(STATIC_DIR / "index.html")
 
 
+@app.get("/config")
+def config_page() -> FileResponse:
+    return FileResponse(STATIC_DIR / "config.html")
+
+
 @app.get("/api/route")
 def api_route() -> dict:
     return route_geojson
@@ -39,6 +46,32 @@ def api_route() -> dict:
 @app.get("/api/meta")
 def api_meta() -> dict:
     return route_meta
+
+
+class ConfigUpdate(BaseModel):
+    start_time: str
+    end_time: str
+
+
+def _parse_iso(value: str) -> datetime:
+    """Parse an ISO 8601 string into a ``datetime`` with timezone awareness."""
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+@app.post("/api/config")
+def api_config(update: ConfigUpdate) -> dict:
+    """Update start and end times for the tracker."""
+    start = _parse_iso(update.start_time)
+    end = _parse_iso(update.end_time)
+    route_meta["start_time"] = start.isoformat()
+    route_meta["end_time"] = end.isoformat()
+    duration = (end - start).total_seconds() or 1
+    route_meta["days"] = max((end - start).days, 1)
+    route_meta["speed_mps"] = (
+        route_meta.get("total_distance_km", 0) * 1000 / duration
+    )
+    route_meta["daily_distance_km"] = route_meta.get("total_distance_km", 0) / route_meta["days"]
+    return {"status": "ok"}
 
 
 if __name__ == "__main__":

--- a/src/app/static/config.html
+++ b/src/app/static/config.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Configuration</title>
+  </head>
+  <body>
+    <h1>Configure Dates</h1>
+    <label>
+      Start time:
+      <input type="datetime-local" id="start" />
+    </label>
+    <br />
+    <label>
+      End time:
+      <input type="datetime-local" id="end" />
+    </label>
+    <br />
+    <button id="saveBtn">Save</button>
+    <script>
+      async function load() {
+        const res = await fetch('/api/meta');
+        const meta = await res.json();
+        const start = new Date(meta.start_time);
+        const end = new Date(meta.end_time);
+        document.getElementById('start').value = start.toISOString().slice(0,16);
+        document.getElementById('end').value = end.toISOString().slice(0,16);
+      }
+      async function save() {
+        const s = document.getElementById('start').value;
+        const e = document.getElementById('end').value;
+        await fetch('/api/config', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            start_time: new Date(s).toISOString(),
+            end_time: new Date(e).toISOString()
+          })
+        });
+        alert('Saved');
+      }
+      document.getElementById('saveBtn').addEventListener('click', save);
+      load();
+    </script>
+  </body>
+</html>

--- a/src/app/static/index.html
+++ b/src/app/static/index.html
@@ -27,6 +27,16 @@
       #search input {
         width: 200px;
       }
+      #countdown {
+        position: absolute;
+        top: 10px;
+        right: 10px;
+        z-index: 1000;
+        background: #fff;
+        padding: 6px;
+        border-radius: 4px;
+        box-shadow: 0 0 5px rgba(0, 0, 0, 0.3);
+      }
     </style>
   </head>
   <body>
@@ -34,6 +44,7 @@
       <input id="searchBox" type="text" placeholder="Search town or address" />
       <button id="searchBtn">Search</button>
     </div>
+    <div id="countdown"></div>
     <div id="map"></div>
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     <script src="/static/script.js"></script>

--- a/src/app/static/script.js
+++ b/src/app/static/script.js
@@ -10,6 +10,7 @@ let searchMarker;
 let cumulative = [];
 let coords = [];
 let totalLength = 0;
+let countdownTimer;
 
 Promise.all([fetch("/api/meta"), fetch("/api/route")])
   .then((responses) => Promise.all(responses.map((r) => r.json())))
@@ -17,6 +18,7 @@ Promise.all([fetch("/api/meta"), fetch("/api/route")])
     meta = m;
     routeData = r;
     addRoute();
+    setupCountdown();
     setupAnimation();
   });
 
@@ -38,7 +40,34 @@ function addRoute() {
 
 function setupAnimation() {
   updateMarker();
-  setInterval(updateMarker, 10000);
+  const start = Date.parse(meta.start_time);
+  const now = Date.now();
+  const delay = Math.max(start - now, 0);
+  setTimeout(() => {
+    updateMarker();
+    setInterval(updateMarker, 300000);
+  }, delay);
+}
+
+function setupCountdown() {
+  const el = document.getElementById("countdown");
+  const start = Date.parse(meta.start_time);
+  function update() {
+    const now = Date.now();
+    const diff = start - now;
+    if (diff <= 0) {
+      el.textContent = "";
+      clearInterval(countdownTimer);
+      return;
+    }
+    const d = Math.floor(diff / (1000 * 60 * 60 * 24));
+    const h = Math.floor((diff / (1000 * 60 * 60)) % 24);
+    const m = Math.floor((diff / (1000 * 60)) % 60);
+    const s = Math.floor((diff / 1000) % 60);
+    el.textContent = `Starts in ${d}d ${h}h ${m}m ${s}s`;
+  }
+  update();
+  countdownTimer = setInterval(update, 1000);
 }
 
 function updateMarker() {


### PR DESCRIPTION
## Summary
- add `/config` page to update tracker start and end times
- add API endpoint to persist new dates and recompute pacing
- show countdown to start and refresh marker position every 5 minutes

## Testing
- `uv run python -m py_compile $(git ls-files '*.py')`
- `uv run python -m app.main &` (then killed)


------
https://chatgpt.com/codex/tasks/task_e_6893efb912148324b2f88d65ce1d056e