### PR TITLE
feat: improve countdown and testable animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,20 @@ uv run python -m app.main
 
 Then open <http://localhost:8000> in your browser.
 
+### Testing the animation early
+
+To preview the marker's movement before the real event begins, supply a
+`begin` query parameter with an ISO timestamp when loading the page:
+
+```
+http://localhost:8000/?begin=2024-07-01T00:00:00Z
+```
+
+The countdown still references the official start date, but the marker's
+progress will be calculated from the overridden `begin` time. This makes
+it easy to verify that the route and animation behave correctly prior to
+the actual start.
+
 ## Docker
 
 A `Dockerfile` is provided for deployment to platforms such as Fly.io.


### PR DESCRIPTION
## Summary
- show elapsed time after the official start instead of clearing the countdown
- add query parameter `begin` to override animation start time for testing
- document how to preview the animation early

## Testing
- `pytest`
- `node --check src/app/static/script.js`


------
https://chatgpt.com/codex/tasks/task_e_6894ebb3f8a08324b59a392982b1e599