### PR TITLE
Add simple sign-in page using environment credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+APP_USERNAME=your_username
+APP_PASSWORD=your_password
+SECRET_KEY=change_me

--- a/README.md
+++ b/README.md
@@ -15,6 +15,21 @@ uv run python -m app.main
 
 Then open <http://localhost:8000> in your browser.
 
+### Authentication
+
+The application now exposes a simple sign‑in page. Set the desired
+credentials in a `.env` file at the project root:
+
+```
+APP_USERNAME=your_username
+APP_PASSWORD=your_password
+SECRET_KEY=change_me
+```
+
+Visit <http://localhost:8000/login> and sign in with the above username
+and password. Upon successful authentication you will be redirected to
+the main map page.
+
 ### Testing the animation early
 
 To preview the marker's movement before the real event begins, supply a

--- a/src/app/static/login.html
+++ b/src/app/static/login.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Sign In</title>
+  </head>
+  <body>
+    <h1>Sign In</h1>
+    <form method="post" action="/login">
+      <label>Username: <input type="text" name="username" /></label><br />
+      <label>Password: <input type="password" name="password" /></label><br />
+      <button type="submit">Sign In</button>
+    </form>
+    <p id="error" style="color:red;"></p>
+    <script>
+      const params = new URLSearchParams(window.location.search);
+      if (params.get('error')) {
+        document.getElementById('error').textContent = 'Invalid credentials';
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- load username/password from `.env` and store session with middleware
- require authentication for map and config pages with new login/logout routes
- add simple HTML login page and example `.env`
- document new sign-in flow in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895386abf4c8324b491e3cf32756dc9